### PR TITLE
Fix: 여행 계획, 여행 중일 때 날짜 변경 시 지도가 변경되지 않는 오류 수정

### DIFF
--- a/src/components/plan/areaAndPlace/area/Area.tsx
+++ b/src/components/plan/areaAndPlace/area/Area.tsx
@@ -26,7 +26,7 @@ const Area = (props: Props) => {
         <Image src={'/images/svgs/area-pin.svg'} width={20} height={20} alt="여행 지역 아이콘" />
         <p>여행 지역</p>
       </div>
-      <KakaoMap pins={pins[currentPage]} drawLine={true} />
+      <KakaoMap pins={pins[currentPage]} drawLine={true} currentPage={currentPage} />
     </div>
   );
 };

--- a/src/components/plan/areaAndPlace/area/kakaoMap/KakaoMap.tsx
+++ b/src/components/plan/areaAndPlace/area/kakaoMap/KakaoMap.tsx
@@ -10,9 +10,10 @@ import type { PinContentsType } from '@/types/supabase';
 interface Props {
   pins: PinContentsType[];
   drawLine: boolean;
+  currentPage?: number;
 }
 
-const KakaoMap = ({ pins, drawLine }: Props) => {
+const KakaoMap = ({ pins, drawLine, currentPage }: Props) => {
   const { map, makeMap, makeLatLng, makeMarker, makePolyline, makeBounds } = useKakaoMap();
 
   React.useEffect(() => {
@@ -27,7 +28,7 @@ const KakaoMap = ({ pins, drawLine }: Props) => {
     };
 
     init();
-  }, []);
+  }, [currentPage]);
 
   React.useEffect(() => {
     if (map && pins?.length > 0) {


### PR DESCRIPTION
- currentPage를 props로 전달하여 카카오맵을 생성하는 useEffect의 의존성 배열에 추가하여 page가 바뀔 때마다 맵을 새롭게 생성