### PR TITLE
Fix: createClientFromServer 함수내의 cookies 관련 설정 중 set과 remove 제거

### DIFF
--- a/src/utils/supabase/server.ts
+++ b/src/utils/supabase/server.ts
@@ -1,4 +1,4 @@
-import { type CookieOptions, createServerClient } from '@supabase/ssr';
+import { createServerClient } from '@supabase/ssr';
 import { cookies } from 'next/headers';
 
 import type { Database } from '@/types/supabase';
@@ -13,12 +13,6 @@ export const createClientFromServer = async () => {
       cookies: {
         get(name: string) {
           return cookieStore.get(name)?.value;
-        },
-        set(name: string, value: string, options: CookieOptions) {
-          cookieStore.set({ name, value, ...options });
-        },
-        remove(name: string, options: CookieOptions) {
-          cookieStore.set({ name, value: '', ...options });
         },
       },
     },


### PR DESCRIPTION
- 일정 시간이 지났을 때 사이트에 접속하면 "Cookies can only be modified in a Server Action or Route Handle" error가 발생하는 것을 해결하기 위해 set 과 remove를 제거