### PR TITLE
Design: 메인페이지 사이드바 우측 상단 튀어나온 흰 배경 디자인 수정

### DIFF
--- a/src/components/common/providers/animateProvider/AnimateProvider.tsx
+++ b/src/components/common/providers/animateProvider/AnimateProvider.tsx
@@ -16,7 +16,7 @@ const AnimateProvider = ({ children }: { children: React.ReactNode }) => {
   return (
     <main
       className={` relative min-h-screen side-bar-transition sm:ml-0
-      ${shouldNoMargin ? '' : isSideBarOpen ? 'md:ml-[270px]' : 'md:ml-[88px]'}
+      ${shouldNoMargin ? '' : isSideBarOpen ? 'md:pl-[270px]' : 'md:pl-[88px]'}
     `}
     >
       {children}


### PR DESCRIPTION
- main 태그에 margin으로 인한 main 태그 흰 배경이 사이드바 우측 상단에 radius 뒤로 보이는 현상을 padding으로 변경하여 수정