### PR TITLE
fix: sw.ts 푸시 이벤트 함수 변경

### DIFF
--- a/src/api/alarm.ts
+++ b/src/api/alarm.ts
@@ -38,14 +38,6 @@ export const addInviteAlarmList = async (datas: InsertInviteAlarmType[]) => {
         data: {
           click_action: `${window?.location?.origin}/plan/${data.invite_planId}`,
         },
-        webpush: {
-          headers: {
-            TTL: '3600',
-          },
-          notification: {
-            icon: '/images/android/android-launchericon-144-144.png',
-          },
-        },
       };
 
       await reqSendPush(message);

--- a/src/app/api/push/route.ts
+++ b/src/app/api/push/route.ts
@@ -10,7 +10,7 @@ export const POST = async (req: NextRequest) => {
 
     const serviceAccount: ServiceAccount = {
       projectId: process.env.NEXT_PUBLIC_FB_PROJECT_ID,
-      privateKey: process.env.NEXT_PUBLIC_FB_PRIVATE_KEY?.replace(/\\n/g, '\n'),
+      privateKey: process.env.FB_PRIVATE_KEY?.replace(/\\n/g, '\n'),
       clientEmail: process.env.NEXT_PUBLIC_CLIENT_EMAIL,
     };
 
@@ -20,8 +20,8 @@ export const POST = async (req: NextRequest) => {
 
     await admin.messaging().send(message);
 
-    return NextResponse.json(message, { status: 200 });
+    return NextResponse.json({ success: true }, { status: 200 });
   } catch (error) {
-    return console.error('Error sending notification:', error);
+    return NextResponse.json({ error: 'Failed to send notification' }, { status: 500 });
   }
 };

--- a/src/app/sw.ts
+++ b/src/app/sw.ts
@@ -1,6 +1,7 @@
 import { defaultCache } from '@serwist/next/worker';
 import { Serwist } from 'serwist';
 
+import type { Message } from 'firebase-admin/messaging';
 import type { PrecacheEntry, SerwistGlobalConfig } from 'serwist';
 
 declare global {
@@ -24,14 +25,8 @@ const firebaseConfig = {
   appId: process.env.NEXT_PUBLIC_FB_APP_ID,
 };
 
-try {
-  // @ts-ignore: Firebase types not fully compatible with ServiceWorker
-  const firebaseApp = self.firebase.initializeApp(firebaseConfig);
-  const messaging = self.firebase.messaging();
-  console.log('Firebase initialized in Service Worker');
-} catch (error) {
-  console.error('Firebase initialization error:', error);
-}
+const firebaseApp = self.firebase.initializeApp(firebaseConfig);
+const messaging = self.firebase.messaging();
 
 const serwist = new Serwist({
   precacheEntries: self.__SW_MANIFEST,
@@ -44,32 +39,56 @@ const serwist = new Serwist({
 
 serwist.addEventListeners();
 
-self.addEventListener('push', (event) => {
-  console.log('Push event received:', event.data?.text());
-  if (!event.data) return;
+messaging.onBackgroundMessage((payload: Message) => {
+  console.log('백그라운드 메시지 수신:', payload);
+  const { notification, data } = payload;
 
-  try {
-    const payload = event.data.json();
-    const { notification, data } = payload;
+  const title = notification?.title || '여행 초대 알림';
+  const body = notification?.body || data?.body;
+  const icon = '/images/android/android-launchericon-144-144.png';
+  const badge = '/images/android/android-launchericon-72-72.png';
+  const clickAction = data?.click_action || '/';
 
-    const title = notification?.title || data?.title;
-    const body = notification?.body || data?.body;
-    const icon = '/images/android/android-launchericon-144-144.png';
-    const clickAction = data?.click_action || '/';
+  const notificationOptions = {
+    body,
+    icon,
+    badge,
+    data: { click_action: clickAction },
+  };
 
-    if (notification) {
-      event.waitUntil(
-        self.registration.showNotification(title, {
-          body,
-          icon,
-          data: { click_action: clickAction },
-        }),
-      );
-    }
-  } catch (error) {
-    console.error('Push event error:', error);
-  }
+  return self.registration.showNotification(title, notificationOptions);
 });
+
+// self.addEventListener('push', (event) => {
+//   console.log('Push event received:', event.data?.text());
+//   if (!event.data) return;
+
+//   try {
+//     const payload = event.data.json();
+//     const { notification, data } = payload;
+
+//     const title = notification?.title || data?.title;
+//     const body = notification?.body || data?.body;
+//     const image = '/images/android/android-launchericon-144-144.png';
+//     const icon = '/images/android/android-launchericon-72-72.png';
+//     const clickAction = data?.click_action || '/';
+
+//     const options = {
+//       body,
+//       image,
+//       icon,
+//       data: {
+//         click_action: clickAction,
+//       },
+//     };
+
+//     if (notification) {
+//       event.waitUntil(self.registration.showNotification(title, options));
+//     }
+//   } catch (error) {
+//     console.error('Push event error:', error);
+//   }
+// });
 
 self.addEventListener('notificationclick', (event) => {
   event.notification.close();


### PR DESCRIPTION
- firebase의 messaging 사용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 푸시 알림에서 웹 푸시 관련 헤더 및 아이콘 메타데이터가 제거되어, 알림의 웹 푸시 전용 정보가 더 이상 포함되지 않습니다.
  - 푸시 메시지 전송 성공 시 반환값이 단순 성공 플래그로 변경되고, 오류 발생 시 에러 메시지와 함께 500 상태 코드가 반환됩니다.

- **리팩터**
  - 서비스 워커의 Firebase 초기화 및 백그라운드 메시지 처리 방식이 간소화되어, 알림 수신 및 표시 로직이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->