### PR TITLE
fix: 상대방의 fcm 토큰이 유효하지 않을 때 오류처리 추가

### DIFF
--- a/src/api/alarm.ts
+++ b/src/api/alarm.ts
@@ -37,6 +37,7 @@ export const addInviteAlarmList = async (datas: InsertInviteAlarmType[]) => {
         },
         data: {
           click_action: `${window?.location?.origin}/plan/${data.invite_planId}`,
+          invited_user_id: data.invite_to,
         },
       };
 

--- a/src/api/notification.ts
+++ b/src/api/notification.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 
 import { getNotificationToken } from '@/firebase/firebase';
 import { is30DaysPast } from '@/utils/aboutDay';
@@ -36,7 +36,14 @@ export const getTargetUserNotificationToken = async (userId: string) => {
 };
 
 export const reqSendPush = async (args: Message) => {
-  await axios.post(window?.location?.origin + '/api/push', args);
+  try {
+    await axios.post(window?.location?.origin + '/api/push', args);
+  } catch (error) {
+    if (error instanceof AxiosError) {
+      const errorUserId = error.response?.data.invited_user_id as string | undefined;
+      await deleteTargetUserToken(errorUserId);
+    }
+  }
 };
 
 export const checkTokenTime = async (userId: string, tokenData: UserTokenData) => {
@@ -51,4 +58,15 @@ export const checkTokenTime = async (userId: string, tokenData: UserTokenData) =
   }
 
   return null;
+};
+
+const deleteTargetUserToken = async (targetId: string | undefined) => {
+  if (!targetId) return;
+
+  const { error } = await supabaseClientClient
+    .from('users')
+    .update({ push_notification: null })
+    .eq('id', targetId);
+
+  if (error) throw new Error('오류 푸시 알림 토큰 삭제 오류');
 };

--- a/src/app/api/push/route.ts
+++ b/src/app/api/push/route.ts
@@ -1,13 +1,12 @@
 import admin from 'firebase-admin';
+import { FirebaseMessagingError, type Message } from 'firebase-admin/messaging';
 import { type NextRequest, NextResponse } from 'next/server';
 
 import type { ServiceAccount } from 'firebase-admin';
-import type { Message } from 'firebase-admin/messaging';
 
 export const POST = async (req: NextRequest) => {
+  const message: Message = await req.json();
   try {
-    const message: Message = await req.json();
-
     const serviceAccount: ServiceAccount = {
       projectId: process.env.NEXT_PUBLIC_FB_PROJECT_ID,
       privateKey: process.env.FB_PRIVATE_KEY?.replace(/\\n/g, '\n'),
@@ -22,6 +21,12 @@ export const POST = async (req: NextRequest) => {
 
     return NextResponse.json({ success: true }, { status: 200 });
   } catch (error) {
-    return NextResponse.json({ error: 'Failed to send notification' }, { status: 500 });
+    if (error instanceof FirebaseMessagingError) {
+      return NextResponse.json(
+        { invited_user_id: message?.data?.invited_user_id },
+        { status: 500 },
+      );
+    }
+    return NextResponse.json({ error: '여행 초대 알림 오류' }, { status: 500 });
   }
 };

--- a/src/components/common/form/postPlanForm/PostPlanForm.tsx
+++ b/src/components/common/form/postPlanForm/PostPlanForm.tsx
@@ -97,9 +97,10 @@ export default function PostPlanForm(props: Props) {
       await addPlan(addPlanData);
 
       const alarmData = changeToAlarmData({ currentUser: user, plan: newPlan, invitedUser });
-      await addInviteAlarmList(alarmData);
 
       toast.success('여행이 생성됐습니다.');
+
+      await addInviteAlarmList(alarmData);
       router.push('main');
     } else {
       const updatedPlan: InsertPlanType = {
@@ -128,12 +129,12 @@ export default function PostPlanForm(props: Props) {
         oldUser: oldInvitedUser,
       });
 
-      await addInviteAlarmList(alarmData);
-
       pinMutate([plan.id, plan.dates]);
       setReadOnly();
       syncInvitedUser();
       toast.success('여행이 수정됐습니다.');
+
+      await addInviteAlarmList(alarmData);
     }
   };
 


### PR DESCRIPTION
- 사용자 편의를 위해 동행 추가 후 알림 처리로 순서 변경
- 보내는 데이터에 타겟 userId 추가, error 시 return
- return 받은 id로 타겟 토큰 삭제하는 로직 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 푸시 알림 요청 실패 시, 잘못된 사용자의 푸시 토큰을 자동으로 삭제하여 오류를 방지합니다.
- **기능 개선**
	- 푸시 알림 데이터에 초대된 사용자의 ID가 추가되어 더욱 정확한 알림 처리가 가능합니다.
	- 여행 계획 추가/수정 시 알림 전송 순서를 개선하여 사용자 경험이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->